### PR TITLE
Do not pass negative rows count to insert

### DIFF
--- a/filesystemmodel.cpp
+++ b/filesystemmodel.cpp
@@ -237,7 +237,11 @@ void FilesystemModel::fetchMore(const QModelIndex &parent)
 	QDir dir = QDir(fileInfo.absoluteFilePath());
 	QFileInfoList children = dir.entryInfoList(QStringList(), QDir::AllEntries | QDir::NoDotAndDotDot, QDir::Name);
 
-	beginInsertRows(parent, 0, children.size() - 1);
+	int insrtCnt = children.size() - 1;
+	if (insrtCnt < 0) {
+		insrtCnt = 0;
+	}
+	beginInsertRows(parent, 0, insrtCnt);
 	parentInfo->children.reserve(children.size());
 	for (const QFileInfo& entry: children) {
 		NodeInfo nodeInfo(entry, parentInfo);


### PR DESCRIPTION
In case of empty folder negative row number (-1) could be passed to insertRow model function within fetchMore function. Newer Qt versions seems to crash on this event.
This commit replaces -1 with 0 in this case fixing the issue. Inserting cannot be omited because model data should be invalidated to hide "+" sign on the empty folder

Fixes #1
